### PR TITLE
[Doppins] Upgrade dependency PyJWT to ==1.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ fanout==1.2.0
 pubcontrol==2.2.7
 # sha256: oWyrBlHZmhlpA-RlIVmDdWLwRT7li7rZ6sydOwD-sBk
 # sha256: 4bI4bPrVQURbHUPkgLAso37Fcln9GiPnlBW1e6XYppQ
-PyJWT==1.4.0
+PyJWT==1.4.1
 # sha256: ET-7pVManjSUW302szoIToul0GZLcDyBp8Vy2RkZpbg
 # sha256: xXeBXdAPE5QgP8ROuXlySwmPiCZKnviY7kW45enPWH8
 requests==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ fanout==1.2.0
 pubcontrol==2.2.7
 # sha256: oWyrBlHZmhlpA-RlIVmDdWLwRT7li7rZ6sydOwD-sBk
 # sha256: 4bI4bPrVQURbHUPkgLAso37Fcln9GiPnlBW1e6XYppQ
-PyJWT==1.4.1
+PyJWT==1.4.2
 # sha256: ET-7pVManjSUW302szoIToul0GZLcDyBp8Vy2RkZpbg
 # sha256: xXeBXdAPE5QgP8ROuXlySwmPiCZKnviY7kW45enPWH8
 requests==2.9.1


### PR DESCRIPTION
Hi!

A new version was just released of `PyJWT`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded PyJWT from `==1.4.0` to `==1.4.1`

